### PR TITLE
Improved reporting when missing mime types

### DIFF
--- a/mediasoup-client/deps/libmediasoupclient/src/ortc.cpp
+++ b/mediasoup-client/deps/libmediasoupclient/src/ortc.cpp
@@ -103,11 +103,13 @@ namespace mediasoupclient
 			if (mimeTypeIt == codec.end() || !mimeTypeIt->is_string())
 				MSC_THROW_TYPE_ERROR("missing codec.mimeType");
 
+			auto mimeType = mimeTypeIt->get<std::string>();
+
 			std::smatch mimeTypeMatch;
-			std::regex_match(mimeTypeIt->get<std::string>(), mimeTypeMatch, MimeTypeRegex);
+			std::regex_match(mimeType, mimeTypeMatch, MimeTypeRegex);
 
 			if (mimeTypeMatch.empty())
-				MSC_THROW_TYPE_ERROR("invalid codec.mimeType");
+				MSC_THROW_TYPE_ERROR("invalid codec.mimeType (%s)", mimeType.c_str());
 
 			// Just override kind with media component of mimeType.
 			codec["kind"] = mimeTypeMatch[1].str();
@@ -346,11 +348,13 @@ namespace mediasoupclient
 			if (mimeTypeIt == codec.end() || !mimeTypeIt->is_string())
 				MSC_THROW_TYPE_ERROR("missing codec.mimeType");
 
+			auto mimeType = mimeTypeIt->get<std::string>();
+
 			std::smatch mimeTypeMatch;
-			std::regex_match(mimeTypeIt->get<std::string>(), mimeTypeMatch, MimeTypeRegex);
+			std::regex_match(mimeType, mimeTypeMatch, MimeTypeRegex);
 
 			if (mimeTypeMatch.empty())
-				MSC_THROW_TYPE_ERROR("invalid codec.mimeType");
+				MSC_THROW_TYPE_ERROR("invalid codec.mimeType (%s)", mimeType.c_str());
 
 			// payloadType is mandatory.
 			if (payloadTypeIt == codec.end() || !payloadTypeIt->is_number_integer())


### PR DESCRIPTION
While debugging the "invalid codec.mimeType" problem (#29) I found it useful to report the actual identifier of the missing mime type. Oddly the problem went away when I compiled with this change (i.e. I can now target the single _armeabi-v7a_ ABI without seeing the problem at runtime. I doubt it was this change that fixed it, probably just compiling in a different environment.