### PR TITLE
Add PeerConnection.Options to Device.load()

### DIFF
--- a/mediasoup-client/build.gradle
+++ b/mediasoup-client/build.gradle
@@ -72,7 +72,7 @@ publish {
     userOrg = 'haiyangwu'
     groupId = 'org.mediasoup.droid'
     artifactId = 'mediasoup-client'
-    publishVersion = '3.0.8-beta-3'
+    publishVersion = '3.0.8-beta-4'
     desc = 'mediasoup android client side library'
     website = 'https://github.com/haiyangwu/mediasoup-client-android'
 }

--- a/mediasoup-client/src/androidTest/java/org/mediasoup/droid/DeviceTest.java
+++ b/mediasoup-client/src/androidTest/java/org/mediasoup/droid/DeviceTest.java
@@ -90,7 +90,7 @@ public class DeviceTest extends BaseTest {
     assertFalse(TextUtils.isEmpty(routerRtpCapabilities));
 
     // 'device->Load()' succeeds.
-    mDevice.load(routerRtpCapabilities);
+    mDevice.load(routerRtpCapabilities, null);
     assertTrue(mDevice.isLoaded());
     assertFalse(TextUtils.isEmpty(mDevice.getRtpCapabilities()));
     assertTrue(mDevice.canProduce("audio"));

--- a/mediasoup-client/src/androidTest/java/org/mediasoup/droid/MediasoupClientTest.java
+++ b/mediasoup-client/src/androidTest/java/org/mediasoup/droid/MediasoupClientTest.java
@@ -107,20 +107,20 @@ public class MediasoupClientTest extends BaseTest {
     // device->load() with invalid routerRtpCapabilities throws.
     {
       final String cap = Parameters.nativeGenRouterRtpCapabilitiesExclude("mimeType");
-      exceptionException(() -> device.load(cap));
+      exceptionException(() -> device.load(cap, null));
     }
 
     // device->load() succeeds.
     {
       routerRtpCapabilities = Parameters.nativeGenRouterRtpCapabilities();
-      device.load(routerRtpCapabilities);
+      device.load(routerRtpCapabilities, null);
       assertTrue(device.isLoaded());
     }
 
     // device->load() rejects if already loaded.
     {
       final String cap = routerRtpCapabilities;
-      exceptionException(() -> device.load(cap));
+      exceptionException(() -> device.load(cap, null));
     }
 
     // 'device->getRtpCapabilities()' succeeds".

--- a/mediasoup-client/src/main/java/org/mediasoup/droid/Device.java
+++ b/mediasoup-client/src/main/java/org/mediasoup/droid/Device.java
@@ -14,9 +14,16 @@ public class Device {
     mNativeDevice = 0;
   }
 
-  public void load(String routerRtpCapabilities) throws MediasoupException {
+  public void load(String routerRtpCapabilities, PeerConnection.Options options) throws MediasoupException {
     checkDeviceExists();
-    nativeLoad(mNativeDevice, routerRtpCapabilities);
+    nativeLoad(
+            mNativeDevice,
+            routerRtpCapabilities,
+            (options != null ? options.mRTCConfig : null),
+            (options != null && options.mFactory != null
+                    ? options.mFactory.getNativePeerConnectionFactory()
+                    : 0L)
+    );
   }
 
   public boolean isLoaded() {
@@ -116,7 +123,12 @@ public class Device {
   private static native void nativeFreeDevice(long device);
 
   // may throws MediasoupException;
-  private static native void nativeLoad(long device, String routerRtpCapabilities);
+  private static native void nativeLoad(
+    long device,
+    String routerRtpCapabilities,
+    org.webrtc.PeerConnection.RTCConfiguration configuration,
+    long peerConnectionFactory
+  );
 
   private static native boolean nativeIsLoaded(long device);
 

--- a/mediasoup-client/src/main/java/org/mediasoup/droid/Device.java
+++ b/mediasoup-client/src/main/java/org/mediasoup/droid/Device.java
@@ -17,12 +17,12 @@ public class Device {
   public void load(String routerRtpCapabilities, PeerConnection.Options options) throws MediasoupException {
     checkDeviceExists();
     nativeLoad(
-            mNativeDevice,
-            routerRtpCapabilities,
-            (options != null ? options.mRTCConfig : null),
-            (options != null && options.mFactory != null
-                    ? options.mFactory.getNativePeerConnectionFactory()
-                    : 0L)
+        mNativeDevice,
+        routerRtpCapabilities,
+        (options != null ? options.mRTCConfig : null),
+        (options != null && options.mFactory != null
+                ? options.mFactory.getNativePeerConnectionFactory()
+                : 0L)
     );
   }
 

--- a/mediasoup-client/src/main/jni/device_jni.cpp
+++ b/mediasoup-client/src/main/jni/device_jni.cpp
@@ -29,14 +29,20 @@ static void JNI_Device_FreeDevice(JNIEnv* env, jlong j_device)
 }
 
 static void JNI_Device_Load(
-  JNIEnv* env, jlong j_device, const JavaParamRef<jstring>& j_routerRtpCapabilities)
+  JNIEnv* env,
+  jlong j_device,
+  const JavaParamRef<jstring>& j_routerRtpCapabilities,
+  const JavaParamRef<jobject>& j_config,
+  jlong j_peerConnection_factory)
 {
 	MSC_TRACE();
 
 	try
 	{
 		auto capabilities = JavaToNativeString(env, j_routerRtpCapabilities);
-		reinterpret_cast<Device*>(j_device)->Load(json::parse(capabilities));
+        PeerConnection::Options options;
+        JavaToNativeOptions(env, j_config, j_peerConnection_factory, options);
+		reinterpret_cast<Device*>(j_device)->Load(json::parse(capabilities), &options);
 	}
 	catch (const std::exception& e)
 	{

--- a/mediasoup-client/src/main/jni/generated_mediasoupclient_jni/jni/Device_jni.h
+++ b/mediasoup-client/src/main/jni/generated_mediasoupclient_jni/jni/Device_jni.h
@@ -55,15 +55,20 @@ JNI_GENERATOR_EXPORT void Java_org_mediasoup_droid_Device_nativeFreeDevice(
 }
 
 static void JNI_Device_Load(JNIEnv* env, jlong device,
-    const base::android::JavaParamRef<jstring>& routerRtpCapabilities);
+    const base::android::JavaParamRef<jstring>& routerRtpCapabilities,
+    const base::android::JavaParamRef<jobject>& configuration,
+    jlong peerConnectionFactory);
 
 JNI_GENERATOR_EXPORT void Java_org_mediasoup_droid_Device_nativeLoad(
     JNIEnv* env,
     jclass jcaller,
     jlong device,
-    jstring routerRtpCapabilities) {
+    jstring routerRtpCapabilities,
+    jobject configuration,
+    jlong peerConnectionFactory) {
   return JNI_Device_Load(env, device, base::android::JavaParamRef<jstring>(env,
-      routerRtpCapabilities));
+      routerRtpCapabilities), base::android::JavaParamRef<jobject>(env, configuration),
+      peerConnectionFactory);
 }
 
 static jboolean JNI_Device_IsLoaded(JNIEnv* env, jlong device);


### PR DESCRIPTION
I'm not a C++ dev at all, so it's just a monkey copy-pasting some code from JNI_Device_CreateSendTransport to JNI_Device_Load. 

What was done:
- Added options parameter to `Device.load(String routerRtpCapabilities, PeerConnection.Options options)`
- Updated `Device.nativeLoad`
- Updated jni headers with `jni-generator.sh`
- Updated JNI_Device_Load in `device_jni.cpp`
- Fixed tests

Why was it done?
To fix the issue #12, the problem is with multiple instances of PeerConnectionFactory created by mediasoup-client internally. So, applications must provide a shared instance using options in `Device.load` `Device.createSendTransport` and `Device.createRecvTransport`

```
final String routerRtpCapabilities = mProtoo.syncRequest("getRouterRtpCapabilities");
final PeerConnection.Options options = new PeerConnection.Options();
options.setFactory(mPeerConnectionUtils.getSharedPeerConnectionFactory(mContext));
mMediasoupDevice = new Device();
mMediasoupDevice.load(routerRtpCapabilities, options);
```