### PR TITLE
Use client webrtc factory even if configuration is null

### DIFF
--- a/mediasoup-client/src/main/jni/java_types.cpp
+++ b/mediasoup-client/src/main/jni/java_types.cpp
@@ -22,11 +22,6 @@ std::string JavaToNativeString(JNIEnv* jni, const JavaRef<jstring>& j_string)
 void JavaToNativeOptions(
   JNIEnv* env, const JavaRef<jobject>& configuration, jlong factory, PeerConnection::Options& options)
 {
-	if (configuration.is_null())
-	{
-		return;
-	}
-
 	if (!configuration.is_null())
 	{
 		webrtc::PeerConnectionInterface::RTCConfiguration rtc_config(


### PR DESCRIPTION
Hi,

Webrtc PeerConnection.Options factory and configuration are optionals.

This should use the factory even if the configuration is null.


